### PR TITLE
Codex change attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Open `index.html` in a browser or host it on any web server. It uses the local `
 
 The map will not push surrounding elements around when zooming since the SVG is contained within the page and only its internal transform changes.
 
-Links embedded inside the SVG behave differently for desktop and mobile users. On desktop, navigation is cancelled if the map was dragged since the last pointer down so you don't accidentally follow a county link while panning. On touch devices, tapping a link pauses the panzoom interactions so the destination opens normally even after moving the map.
+Links embedded inside the SVG behave differently for desktop and mobile users. On desktop, navigation is cancelled if the mouse dragged the map before the click. Each `<a>` element intercepts the click event and ignores it when the previous interaction was a pan. On touch devices, tapping a link pauses the panzoom interactions so the destination opens normally even after moving the map.

--- a/index.html
+++ b/index.html
@@ -128,15 +128,21 @@ a:hover path {
       let wasPan = false;
       const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
       panZoom.on('panstart', () => { wasPan = false; });
-      panZoom.on('transform', () => { wasPan = true; });
+      panZoom.on('pan', () => { wasPan = true; });
 
-      svg.addEventListener('click', function(event) {
-        if (!isTouchDevice && wasPan) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
-        wasPan = false;
-      }, true);
+      svg.querySelectorAll('a').forEach(function(link) {
+        link.addEventListener(
+          'click',
+          function(event) {
+            if (!isTouchDevice && wasPan) {
+              event.preventDefault();
+              event.stopPropagation();
+            }
+            wasPan = false;
+          },
+          true
+        );
+      });
 
       if (isTouchDevice) {
         svg.querySelectorAll('a').forEach(function(link) {


### PR DESCRIPTION
Mobile issue was solved--links were clickable, pinch to zoom in/out worked OK.  However, the desktop issue persisted where clicking the map to pan would activate the underlying URL upon mouse button release.