### PR TITLE
Fix daily reflection fallback cleaning

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -28,14 +28,22 @@ const sample3=`Daily Reflection\nSubmit Common Searches:\n\nPlain text via A.A. 
 
 const sample4=fs.readFileSync(new URL('../tests/sample-plain.txt', import.meta.url), 'utf8');
 
+const sample5=`Daily Reflection\n[Skip to main content]\nSuper Navigation * Find Help\n\nPlain text via A.A. World Services \u2022 View archive`;
+
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
   expect(title).toBe('Daily Reflection');
   expect(body).toBe('');
 });
 
-test('filters meetings and anonymity links',()=>{
+test('filters contribution and bookstore lines',()=>{
   const {title,body}=parsePlainText(sample4);
+  expect(title).toBe('Daily Reflection');
+  expect(body).toBe('');
+});
+
+test('filters skip links and super navigation',()=>{
+  const {title,body}=parsePlainText(sample5);
   expect(title).toBe('Daily Reflection');
   expect(body).toBe('');
 });

--- a/tests/sample-plain.txt
+++ b/tests/sample-plain.txt
@@ -1,4 +1,3 @@
 Daily Reflection
-Super Navigation * [Find A.A. Near You](http://www.aa.org/find-aa)
-
+Make a Contribution * Online Bookstore
 Plain text via A.A. World Services • View archive

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -1,8 +1,9 @@
 export function parsePlainText(md){
   const lines=md.split(/\n+/).map(l=>l.trim());
   const isJunk=l=>!l||
-    /^(Title:?|URL|URL Source|Source|Published|Markdown|Submit|Common Searches:|Daily Reflections?\b|Daily Reflection\b|\[Skip|\[Search|Search\s+\[x\]|=+$|-+$)/i.test(l)||
-    /alcoholics anonymous|aa grapevine|A\.A\. World Services|View archive|Plain text via|Super Navigation|Find A\.A\./i.test(l)||
+    /^(Title:?|URL|URL Source|Source|Published|Markdown|Submit|Common Searches:|Make a Contribution|Online Bookstore|Daily Reflections?\b|Daily Reflection\b|\[Skip|\[Search|Search\s+\[x\]|=+$|-+$)/i.test(l)||
+    /alcoholics anonymous|aa grapevine|A\.A\. World Services|View archive|Plain text via|Super Navigation|Find A\.A\.|Contribution|Bookstore/i.test(l)||
+    /\[[^\]]+\]/.test(l)||
     /^\[[^\]]+\]\([^)]*\)(\s+\[[^\]]+\]\([^)]*\))*$/.test(l)||
     l.startsWith('javascript:void');
   const clean=lines.filter(l=>!isJunk(l));

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><title>Daily Reflection</title>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
-<style>:root{--fern:#4b6b43;--stone:#7d8c74}html,body{margin:0;padding:0;font-family:Montserrat,Arial,sans-serif;background:#fff}#card{max-width:420px;margin:0 auto;padding:1.4rem 1.6rem;border:2px solid var(--stone);border-radius:12px;box-shadow:0 2px 6px #0002}h2{margin:0 0 .6rem;font-size:1.2rem;color:var(--fern)}p{margin:.6rem 0;font-size:1rem;line-height:1.35;color:#333}small{display:block;margin-top:1.2rem;font-size:.78rem;color:#666}</style>
+<style>:root{--fern:#4b6b43;--stone:#7d8c74}html,body{margin:0;padding:0;font-family:Montserrat,Arial,sans-serif;background:#fff}#card{max-width:420px;margin:0 auto;padding:1.4rem 1.6rem;border:2px solid var(--stone);border-radius:12px;box-shadow:0 2px 6px #0002}h2{margin:0 0 .6rem;font-size:1.2rem;color:var(--fern)}p{margin:.6rem 0;font-size:1rem;line-height:1.35;color:#333}</style>
 </head><body>
 <div id="card"><h2>Loading …</h2><p>Fetching today’s Daily Reflection.</p></div>
 <script type="module" src="daily-reflections.js"></script>

--- a/widgets/daily-reflections.js
+++ b/widgets/daily-reflections.js
@@ -6,15 +6,13 @@ const prox1=u=>'https://api.allorigins.win/raw?url='+encodeURIComponent(u);
 const prox2=u=>'https://r.jina.ai/http://'+u.replace(/^https?:\/\//,'');
 
 const card=document.getElementById('card');
-function render(t,txt,src){
-  card.innerHTML=`<h2>${t}</h2><p>${txt}</p>`+
-  `<small>${src} via A.A. World Services • `+
-  `<a href="https://www.aa.org/daily-reflections" target="_blank" style="color:var(--fern);text-decoration:none">View archive</a></small>`;
+function render(t,txt){
+  card.innerHTML=`<h2>${t}</h2><p>${txt}</p>`;
 }
 
 function parsePlain(md){
   const {title,body}=parsePlainText(md);
-  if(body) render(title,body,'Plain text');
+  if(body) render(title,body);
   else throw 0;
 }
 
@@ -25,7 +23,7 @@ function parseHtml(html,src){
   let body='',n=h?.nextElementSibling;
   while(n&&n.tagName==='P'){body+=n.textContent.trim()+' ';n=n.nextElementSibling;}
   body=body.trim();
-  if(body) render(h?h.textContent.trim():'Daily Reflection',body,src); else throw 0;
+  if(body) render(h?h.textContent.trim():'Daily Reflection',body); else throw 0;
 }
 
 function scrape(){
@@ -35,7 +33,7 @@ function scrape(){
     .catch(()=>fetch(prox2(PAGE),{cache:'no-store'})
       .then(r=>r.ok?r.text():Promise.reject())
       .then(t=>parsePlain(t))
-      .catch(()=>render('Daily Reflection','Sorry — unable to load today\u2019s reading.','Error')));
+      .catch(()=>render('Daily Reflection','Sorry — unable to load today\u2019s reading.')));
 }
 
 fetch(prox1(FEED),{cache:'no-store'}).then(r=>r.ok?r.text():Promise.reject())
@@ -44,6 +42,6 @@ fetch(prox1(FEED),{cache:'no-store'}).then(r=>r.ok?r.text():Promise.reject())
   const i=d.querySelector('item');
   const title=i?.querySelector('title')?.textContent.trim();
   const body=i?.querySelector('description')?.textContent?.replace(/<[^>]+>/g,'').trim();
-  if(title&&body) return render(title,body,'RSS');
+  if(title&&body) return render(title,body);
   throw 0;
 }).catch(()=>scrape());


### PR DESCRIPTION
## Summary
- clean up unwanted lines from plain text fallback
- show only title and body in the reflection card
- update widget styles
- add regression tests for navigation junk removal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870b1d4dedc83279eecb9be9df6b4d0