### PR TITLE
Switch daily reflections to HTML parsing fallback

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -1,4 +1,4 @@
-import {parsePlainText} from '../widgets/daily-reflections-lib.js';
+import {parsePlainText, parseDailyHtml} from '../widgets/daily-reflections-lib.js';
 import fs from 'fs';
 
 const sample1=`Daily Reflections | Alcoholics Anonymous
@@ -46,4 +46,14 @@ test('filters skip links and super navigation',()=>{
   const {title,body}=parsePlainText(sample5);
   expect(title).toBe('Daily Reflection');
   expect(body).toBe('');
+});
+
+const html=fs.readFileSync(new URL('../tests/fixtures/daily-reflections.html', import.meta.url),'utf8');
+
+test('parses saved daily reflections html',()=>{
+  const {title,body}=parseDailyHtml(html);
+  expect(title).toBe('ASKING FOR HELP');
+  expect(body.length).toBeGreaterThan(100);
+  expect(body).not.toMatch(/Make a Contribution/);
+  expect(body).not.toMatch(/Select your language Mega Menu/);
 });

--- a/tests/fixtures/daily-reflections.html
+++ b/tests/fixtures/daily-reflections.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Daily Reflection</title></head>
+<body>
+<nav>[Select your language Mega Menu]</nav>
+<main>
+<h2>ASKING FOR HELP</h2>
+<p>When we reach out for help, we join a fellowship built on trust and mutual support. This connection is vital to recovery and keeps us grounded in the principles of the program.</p>
+<p>By sharing our experiences, we open the door to honesty and healing. These daily reflections remind us that together we can do what we could not do alone.</p>
+<div>Make a Contribution</div>
+</main>
+</body>
+</html>

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -18,3 +18,23 @@ export function parsePlainText(md){
   }
   return {title, body:body.join(' ').trim()};
 }
+
+export function parseDailyHtml(html){
+  const strip=t=>t.replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+  html=html.replace(/<script[^>]*>[\s\S]*?<\/script>|<style[^>]*>[\s\S]*?<\/style>/gi,'');
+  const main=html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1]||'';
+  const h=main.match(/<(h1|h2)[^>]*>([\s\S]*?)<\/\1>/i);
+  const title=h?strip(h[2]):'Daily Reflection';
+  let rest=main.slice(h?main.indexOf(h[0])+h[0].length:0).trimStart();
+  const ps=[];
+  const pRe=/<p[^>]*>([\s\S]*?)<\/p>/ig;
+  let m,last=0;
+  while((m=pRe.exec(rest))){
+    if(m.index>last && /[^\s]/.test(rest.slice(last,m.index))) break;
+    ps.push(strip(m[1]));
+    last=pRe.lastIndex;
+  }
+  const body=ps.join(' ').trim();
+  const res=parsePlainText(`### ${title}\n${body}`);
+  return res.body?res:{title,body};
+}

--- a/widgets/daily-reflections.js
+++ b/widgets/daily-reflections.js
@@ -1,5 +1,5 @@
 // Daily Reflections widget logic
-import {parsePlainText} from './daily-reflections-lib.js';
+import {parsePlainText, parseDailyHtml} from './daily-reflections-lib.js';
 const FEED='https://www.aa.org/sites/default/files/feed-en-aaregroom-calendar.xml';
 const PAGE='https://www.aa.org/daily-reflections';
 const prox1=u=>'https://api.allorigins.win/raw?url='+encodeURIComponent(u);
@@ -16,20 +16,15 @@ function parsePlain(md){
   else throw 0;
 }
 
-function parseHtml(html,src){
-  if(!html.trim().startsWith('<')) throw 0;
-  const doc=new DOMParser().parseFromString(html,'text/html');
-  const h=doc.querySelector('main h1,h2,h3');
-  let body='',n=h?.nextElementSibling;
-  while(n&&n.tagName==='P'){body+=n.textContent.trim()+' ';n=n.nextElementSibling;}
-  body=body.trim();
-  if(body) render(h?h.textContent.trim():'Daily Reflection',body); else throw 0;
+function parseHtml(html){
+  const {title,body}=parseDailyHtml(html);
+  if(body) render(title,body); else throw 0;
 }
 
 function scrape(){
   fetch(prox1(PAGE),{cache:'no-store'})
     .then(r=>r.ok?r.text():Promise.reject())
-    .then(h=>parseHtml(h,'HTML via AllOrigins'))
+    .then(h=>parseHtml(h))
     .catch(()=>fetch(prox2(PAGE),{cache:'no-store'})
       .then(r=>r.ok?r.text():Promise.reject())
       .then(t=>parsePlain(t))


### PR DESCRIPTION
## Summary
- add HTML fallback parser for daily reflections widget
- store fixture HTML for tests
- test new HTML parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871ef795b1083278c7316e0403a9ab2