### PR TITLE
Clean Mega Menu text from Daily Reflections

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -29,6 +29,7 @@ const sample3=`Daily Reflection\nSubmit Common Searches:\n\nPlain text via A.A. 
 const sample4=fs.readFileSync(new URL('../tests/sample-plain.txt', import.meta.url), 'utf8');
 
 const sample5=`Daily Reflection\n[Skip to main content]\nSuper Navigation * Find Help\n\nPlain text via A.A. World Services \u2022 View archive`;
+const sample6=fs.readFileSync(new URL('../tests/fixtures/fail-megamenu.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -44,6 +45,12 @@ test('filters contribution and bookstore lines',()=>{
 
 test('filters skip links and super navigation',()=>{
   const {title,body}=parsePlainText(sample5);
+  expect(title).toBe('Daily Reflection');
+  expect(body).toBe('');
+});
+
+test('filters select your language mega menu',()=>{
+  const {title,body}=parsePlainText(sample6);
   expect(title).toBe('Daily Reflection');
   expect(body).toBe('');
 });

--- a/tests/fixtures/fail-megamenu.txt
+++ b/tests/fixtures/fail-megamenu.txt
@@ -1,0 +1,2 @@
+Daily Reflection
+Select your language Mega Menu

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -2,7 +2,7 @@ export function parsePlainText(md){
   const lines=md.split(/\n+/).map(l=>l.trim());
   const isJunk=l=>!l||
     /^(Title:?|URL|URL Source|Source|Published|Markdown|Submit|Common Searches:|Make a Contribution|Online Bookstore|Daily Reflections?\b|Daily Reflection\b|\[Skip|\[Search|Search\s+\[x\]|=+$|-+$)/i.test(l)||
-    /alcoholics anonymous|aa grapevine|A\.A\. World Services|View archive|Plain text via|Super Navigation|Find A\.A\.|Contribution|Bookstore/i.test(l)||
+    /alcoholics anonymous|aa grapevine|A\.A\. World Services|View archive|Plain text via|Super Navigation|Find A\.A\.|Contribution|Bookstore|Mega Menu|Select your language/i.test(l)||
     /\[[^\]]+\]/.test(l)||
     /^\[[^\]]+\]\([^)]*\)(\s+\[[^\]]+\]\([^)]*\))*$/.test(l)||
     l.startsWith('javascript:void');


### PR DESCRIPTION
## Summary
- add failing mega-menu snippet
- cover the new snippet in tests
- strip `Select your language Mega Menu` from plain text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872939f3b0c83278fc2daaffb4878d3