### PR TITLE
Update widget to use RSS feed with plain text fallback

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -1,4 +1,4 @@
-import {parsePlainText, parseDailyHtml} from '../widgets/daily-reflections-lib.js';
+import {parsePlainText, parseDailyHtml, parseDailyRss} from '../widgets/daily-reflections-lib.js';
 import fs from 'fs';
 
 const sample1=`Daily Reflections | Alcoholics Anonymous
@@ -64,10 +64,19 @@ test('filters left/right navigation line',()=>{
 
 const html=fs.readFileSync(new URL('../tests/fixtures/daily-reflections.html', import.meta.url),'utf8');
 
+const rss=fs.readFileSync(new URL('../tests/fixtures/rss-sample.xml', import.meta.url),'utf8');
+
 test('parses saved daily reflections html',()=>{
   const {title,body}=parseDailyHtml(html);
   expect(title).toBe('ASKING FOR HELP');
   expect(body.length).toBeGreaterThan(100);
   expect(body).not.toMatch(/Make a Contribution/);
   expect(body).not.toMatch(/Select your language Mega Menu/);
+});
+
+test('parses sample rss feed',()=>{
+  const {title,body}=parseDailyRss(rss);
+  expect(title).toBe('ASKING FOR HELP');
+  expect(body.length).toBeGreaterThan(200);
+  expect(body).not.toMatch(/Make a Contribution/);
 });

--- a/tests/fixtures/rss-sample.xml
+++ b/tests/fixtures/rss-sample.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss><channel>
+<title>Daily Reflections</title>
+<item>
+<title>ASKING FOR HELP</title>
+<description><![CDATA[
+<p>When we reach out for help, we join a fellowship built on trust and mutual support. This connection is vital to recovery and keeps us grounded in the principles of the program.</p>
+<p>By sharing our experiences, we open the door to honesty and healing. These daily reflections remind us that together we can do what we could not do alone.</p>
+<div>Make a Contribution</div>
+]]></description>
+</item>
+</channel></rss>

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -38,3 +38,16 @@ export function parseDailyHtml(html){
   const res=parsePlainText(`### ${title}\n${body}`);
   return res.body?res:{title,body};
 }
+
+export function parseDailyRss(xml){
+  const item=xml.match(/<item>([\s\S]*?)<\/item>/i)?.[1]||'';
+  const t=item.match(/<title>([\s\S]*?)<\/title>/i)?.[1]?.trim()||'Daily Reflection';
+  const desc=item.match(/<description>([\s\S]*?)<\/description>/i)?.[1]||'';
+  const clean=desc
+    .replace(/<!\[CDATA\[|\]\]>/g,'')
+    .replace(/<\/?p[^>]*>/gi,'\n')
+    .replace(/<[^>]*>/g,'');
+  const title=t.replace(/<[^>]*>/g,'').trim();
+  const res=parsePlainText(`### ${title}\n${clean}`);
+  return res.body?res:{title,body:res.body?res.body.trim():''};
+}

--- a/widgets/daily-reflections.js
+++ b/widgets/daily-reflections.js
@@ -1,6 +1,6 @@
 // Daily Reflections widget logic
-import {parsePlainText, parseDailyHtml} from './daily-reflections-lib.js';
-const FEED='https://www.aa.org/sites/default/files/feed-en-aaregroom-calendar.xml';
+import {parsePlainText, parseDailyRss} from './daily-reflections-lib.js';
+const FEED='https://www.aa.org/sites/default/files/DailyReflections.xml';
 const PAGE='https://www.aa.org/daily-reflections';
 const prox1=u=>'https://api.allorigins.win/raw?url='+encodeURIComponent(u);
 const prox2=u=>'https://r.jina.ai/http://'+u.replace(/^https?:\/\//,'');
@@ -16,27 +16,18 @@ function parsePlain(md){
   else throw 0;
 }
 
-function parseHtml(html){
-  const {title,body}=parseDailyHtml(html);
-  if(body) render(title,body); else throw 0;
-}
-
 function scrape(){
-  fetch(prox1(PAGE),{cache:'no-store'})
+  fetch(prox2(PAGE),{cache:'no-store'})
     .then(r=>r.ok?r.text():Promise.reject())
-    .then(h=>parseHtml(h))
-    .catch(()=>fetch(prox2(PAGE),{cache:'no-store'})
-      .then(r=>r.ok?r.text():Promise.reject())
-      .then(t=>parsePlain(t))
-      .catch(()=>render('Daily Reflection','Sorry — unable to load today\u2019s reading.')));
+    .then(t=>parsePlain(t))
+    .catch(()=>render('Daily Reflection','Sorry — unable to load today\u2019s reading.'));
 }
 
-fetch(prox1(FEED),{cache:'no-store'}).then(r=>r.ok?r.text():Promise.reject())
-.then(xml=>{
-  const d=new DOMParser().parseFromString(xml,'text/xml');
-  const i=d.querySelector('item');
-  const title=i?.querySelector('title')?.textContent.trim();
-  const body=i?.querySelector('description')?.textContent?.replace(/<[^>]+>/g,'').trim();
-  if(title&&body) return render(title,body);
-  throw 0;
-}).catch(()=>scrape());
+fetch(prox1(FEED),{cache:'no-store'})
+  .then(r=>r.ok?r.text():Promise.reject())
+  .then(xml=>{
+    const {title,body}=parseDailyRss(xml);
+    if(body) return render(title,body);
+    throw 0;
+  })
+  .catch(()=>scrape());


### PR DESCRIPTION
## Summary
- fetch RSS feed for daily reflections and parse first item
- fall back to Jina AI plain text when RSS fails
- add RSS parser and unit tests
- include sample RSS fixture for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68773fcf94808327937795aed93927bd