### PR TITLE
Fix Jina quote dedupe & add attribution footer

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -34,6 +34,7 @@ const sample7=fs.readFileSync(new URL('../tests/fixtures/fail-left-right.txt', i
 
 const jina1=fs.readFileSync(new URL('../tests/__fixtures__/sample-jina.txt', import.meta.url),'utf8');
 const jina2=fs.readFileSync(new URL('../tests/__fixtures__/sample-jina-footer.txt', import.meta.url),'utf8');
+const jinaDup=fs.readFileSync(new URL('../tests/fixtures/dup-quotes-jina.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -88,7 +89,10 @@ test('parses jina sample and strips nav',()=>{
   const res=parseJinaText(jina1);
   expect(res.title).toBe('I AM AN INSTRUMENT');
   expect(res.date).toBe('July 11');
-  expect(res.quote).toBe('We ask simply that throughout the day...\nBig Book p. 86');
+  expect(res.quotes).toEqual([
+    'We ask simply that throughout the day...',
+    'Big Book p. 86'
+  ]);
   expect(res.body).toMatch(/fear cloud my usefulness/);
   expect(res.body).not.toMatch(/Left \* Right/);
 });
@@ -99,4 +103,11 @@ test('stops before footer link',()=>{
   expect(res.date).toBe('May 15');
   expect(res.body).not.toMatch(/Online Bookstore/);
   expect(res.body).toMatch(/Service is at the heart/);
+});
+
+test('dedupes duplicate quote lines',()=>{
+  const res=parseJinaText(jinaDup);
+  expect(res.quotes.length).toBe(2);
+  expect(res.quotes[0]).toMatch(/throughout the day/);
+  expect(res.quotes[1]).toMatch(/Big Book p. 86/);
 });

--- a/tests/fixtures/dup-quotes-jina.txt
+++ b/tests/fixtures/dup-quotes-jina.txt
@@ -1,0 +1,9 @@
+### "I AM AN INSTRUMENT"
+July 11
+** "We ask simply that throughout the day..."
+** Big Book p. 86
+** "We ask simply that throughout the day..."
+** Big Book p. 86
+
+Body line 1
+Body line 2

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -56,7 +56,7 @@ export function parseJinaText(raw){
   raw=raw.replace(/\r/g,'');
   const lines=raw.split('\n');
   let i=0;
-  const out={title:'Daily Reflection',date:'',quote:'',body:''};
+  const out={title:'Daily Reflection',date:'',quotes:[],body:''};
   while(i<lines.length && !/^###\s+/.test(lines[i].trim())) i++;
   if(i<lines.length){
     out.title=lines[i].trim().replace(/^###\s*/,'').replace(/^"|"$/g,'').trim();
@@ -69,10 +69,15 @@ export function parseJinaText(raw){
     let t=lines[i].trim();
     if(!t.startsWith('**')) break;
     t=t.replace(/^\*\*\s*/,'').replace(/\*\*$/,'').replace(/^"|"$/g,'').trim();
-    if(t&&!seen.has(t)){seen.add(t);quotes.push(t);}
+    const key=t.replace(/["'“”‘’]/g,'').toLowerCase();
+    if(t && !seen.has(key)){
+      seen.add(key);
+      quotes.push(t);
+      if(quotes.length>=4) {i++; break;}
+    }
     i++;
   }
-  out.quote=quotes.join('\n');
+  out.quotes=quotes;
   const foot=[/^\*\s+Left/i,/^\*\s+Right/i,/Plain text via/i,/Make a Contribution/i,/Online Bookstore/i,/Select your language/i];
   const paras=[]; let p=[];
   for(;i<lines.length;i++){

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -13,6 +13,8 @@ body{margin:0;font-family:Montserrat,Arial,sans-serif;background:#fff}
 #card .date{margin:.2rem 0 .8rem;font-size:.9rem;color:var(--stone)}
 #card blockquote{margin:.4rem 0;padding-left:1em;border-left:4px solid var(--fern);color:#333}
 #card .body p{margin:.6rem 0;font-size:1rem;line-height:1.4;color:#333}
+#card .quote-src{color:var(--stone);font-size:.9rem;margin:.2rem 0 0}
+#card .dr-foot{font-size:.75rem;color:var(--fog);margin-top:1rem;line-height:1.2}
 </style>
 </head>
 <body>
@@ -27,7 +29,7 @@ function parseJinaText(raw){
   raw=raw.replace(/\r/g,'');
   const lines=raw.split('\n');
   let i=0;
-  const out={title:'Daily Reflection',date:'',quote:'',body:''};
+  const out={title:'Daily Reflection',date:'',quotes:[],body:''};
   while(i<lines.length && !/^###\s+/.test(lines[i].trim())) i++;
   if(i<lines.length){
     out.title=lines[i].trim().replace(/^###\s*/,'').replace(/^"|"$/g,'').trim();
@@ -40,10 +42,15 @@ function parseJinaText(raw){
     let t=lines[i].trim();
     if(!t.startsWith('**')) break;
     t=t.replace(/^\*\*\s*/,'').replace(/\*\*$/,'').replace(/^"|"$/g,'').trim();
-    if(t&&!seen.has(t)){seen.add(t);quotes.push(t);}
+    const key=t.replace(/["'“”‘’]/g,'').toLowerCase();
+    if(t && !seen.has(key)){
+      seen.add(key);
+      quotes.push(t);
+      if(quotes.length>=4){i++;break;}
+    }
     i++;
   }
-  out.quote=quotes.join('\n');
+  out.quotes=quotes;
   const foot=[/^\*\s+Left/i,/^\*\s+Right/i,/Plain text via/i,/Make a Contribution/i,/Online Bookstore/i,/Select your language/i];
   const paras=[];let p=[];
   for(;i<lines.length;i++){
@@ -61,11 +68,19 @@ function render(d){
   if(!d) return card.innerHTML='<p>Unable to load today\'s Daily Reflection.</p>';
   let h=`<h2>${d.title}</h2>`;
   if(d.date) h+=`<div class="date">${d.date}</div>`;
-  if(d.quote) h+=`<blockquote>${d.quote.replace(/\n/g,'<br>')}</blockquote>`;
+  if(d.quotes && d.quotes.length){
+    if(d.quotes.length===1){
+      h+=`<blockquote>${d.quotes[0]}</blockquote>`;
+    }else{
+      const qs=d.quotes.map((q,i)=>`<p${i? ' class="quote-src"':''}>${q}</p>`).join('');
+      h+=`<blockquote>${qs}</blockquote>`;
+    }
+  }
   if(d.body){
     const ps=d.body.split(/\n\n+/).map(p=>`<p>${p}</p>`).join('');
     h+=`<div class="body">${ps}</div>`;
   }
+  h+=`<footer class="dr-foot">From <em>Daily Reflections</em>. Copyright \u00A9 1990 A.A. World Services, Inc. <a href="https://www.aa.org/daily-reflections" target="_blank" rel="noopener">View at AA.org</a></footer>`;
   card.innerHTML=h;
 }
 fetchText().then(t=>render(parseJinaText(t))).catch(()=>render(null));


### PR DESCRIPTION
## Summary
- dedupe quote lines in `parseJinaText`
- render quotes array and copyright footer in widget
- style quote source and footer text
- test duplicate quote handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877488caa848327a43206932ffded60