### PR TITLE
Handle duplicate quotes & limit lines

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -35,6 +35,7 @@ const sample7=fs.readFileSync(new URL('../tests/fixtures/fail-left-right.txt', i
 const jina1=fs.readFileSync(new URL('../tests/__fixtures__/sample-jina.txt', import.meta.url),'utf8');
 const jina2=fs.readFileSync(new URL('../tests/__fixtures__/sample-jina-footer.txt', import.meta.url),'utf8');
 const jinaDup=fs.readFileSync(new URL('../tests/fixtures/dup-quotes-jina.txt', import.meta.url),'utf8');
+const dupQuote=fs.readFileSync(new URL('../tests/fixtures/dup-quote.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -110,4 +111,11 @@ test('dedupes duplicate quote lines',()=>{
   expect(res.quotes.length).toBe(2);
   expect(res.quotes[0]).toMatch(/throughout the day/);
   expect(res.quotes[1]).toMatch(/Big Book p. 86/);
+});
+
+test('dedupes and limits to two quote lines',()=>{
+  const res=parseJinaText(dupQuote);
+  expect(res.quotes.length).toBe(2);
+  expect(res.quotes[0]).toMatch(/My stability came out/);
+  expect(res.quotes[1]).toMatch(/Thus I think it can work out/);
 });

--- a/tests/fixtures/dup-quote.txt
+++ b/tests/fixtures/dup-quote.txt
@@ -1,0 +1,12 @@
+### "SERENITY COMES"
+July 12
+**My stability came out of trying to give, not out of demanding that I receive.**
+**Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.**
+**THE LANGUAGE OF THE HEART, p. 238**
+**My stability came out of trying to give, not out of demanding that I receive.**
+**Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.**
+**THE LANGUAGE OF THE HEART, p. 238**
+
+Body line 1
+Body line 2
+

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -68,12 +68,14 @@ export function parseJinaText(raw){
   while(i<lines.length){
     let t=lines[i].trim();
     if(!t.startsWith('**')) break;
-    t=t.replace(/^\*\*\s*/,'').replace(/\*\*$/,'').replace(/^"|"$/g,'').trim();
-    const key=t.replace(/["'“”‘’]/g,'').toLowerCase();
+    t=t.replace(/^\*\*\s*/,'').replace(/\*\*$/,'').trim();
+    t=t.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
+    t=t.replace(/\s+/g,' ');
+    const key=t.toLowerCase();
     if(t && !seen.has(key)){
       seen.add(key);
       quotes.push(t);
-      if(quotes.length>=4) {i++; break;}
+      if(quotes.length>=2){i++;break;}
     }
     i++;
   }

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -41,12 +41,14 @@ function parseJinaText(raw){
   while(i<lines.length){
     let t=lines[i].trim();
     if(!t.startsWith('**')) break;
-    t=t.replace(/^\*\*\s*/,'').replace(/\*\*$/,'').replace(/^"|"$/g,'').trim();
-    const key=t.replace(/["'“”‘’]/g,'').toLowerCase();
+    t=t.replace(/^\*\*\s*/,'').replace(/\*\*$/,'').trim();
+    t=t.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
+    t=t.replace(/\s+/g,' ');
+    const key=t.toLowerCase();
     if(t && !seen.has(key)){
       seen.add(key);
       quotes.push(t);
-      if(quotes.length>=4){i++;break;}
+      if(quotes.length>=2){i++;break;}
     }
     i++;
   }


### PR DESCRIPTION
## Summary
- cap Jina quote lines at two unique lines
- collapse whitespace and dedupe by canonical lowercase value
- update Daily Reflections HTML implementation
- add new sample dup-quote fixture
- test deduplication and limiting behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68786aac54088327aba20ed329340d02