### PR TITLE
Fix Daily Reflections dedupe & long quotes

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -38,6 +38,7 @@ const jinaDup=fs.readFileSync(new URL('../tests/fixtures/dup-quotes-jina.txt', i
 const dupQuote=fs.readFileSync(new URL('../tests/fixtures/dup-quote.txt', import.meta.url),'utf8');
 const dupQuoteRaw=fs.readFileSync(new URL('../tests/fixtures/dup-quote-raw.txt', import.meta.url),'utf8');
 const dupQuoteVariant=fs.readFileSync(new URL('../tests/fixtures/dup-quote-variant.txt', import.meta.url),'utf8');
+const dupQuoteLong=fs.readFileSync(new URL('../tests/fixtures/dup-quote-long.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -119,7 +120,7 @@ test('dedupes and limits to two quote lines',()=>{
   const res=parseJinaText(dupQuote);
   expect(res.quotes.length).toBe(2);
   expect(res.quotes[0]).toMatch(/My stability came out/);
-  expect(res.quotes[1]).toMatch(/Thus I think it can work out/);
+  expect(res.quotes[1]).toMatch(/THE LANGUAGE OF THE HEART/);
 });
 
 test('dedupes raw curly quote block',()=>{
@@ -132,6 +133,17 @@ test('dedupes raw curly quote block',()=>{
 test('handles punctuation variants',()=>{
   const res=parseJinaText(dupQuoteVariant);
   expect(res.quotes.length).toBe(2);
-  expect(res.quotes[0]).toMatch(/We ask simply/);
-  expect(res.quotes[1]).toMatch(/Big Book p\. 86/);
+  expect(res.quotes[0]).toMatch(/My stability came out/);
+  expect(res.quotes[1]).toMatch(/THE LANGUAGE OF THE HEART/);
+});
+
+test('handles long quote block dedupe and promotion',()=>{
+  const res=parseJinaText(dupQuoteLong);
+  expect(res.quotes.length).toBe(2);
+  expect(res.quotes[0]).toMatch(/My stability came out/);
+  expect(res.quotes[1]).toMatch(/THE LANGUAGE OF THE HEART/);
+  const match=res.body.match(/Thus I think it can work out with emotional sobriety/gi);
+  expect(match?.length).toBe(1);
+  expect(res.body.startsWith('Thus I think it can work out with emotional sobriety')).toBe(true);
+  expect(res.body).not.toMatch(/Left \* Right/);
 });

--- a/tests/fixtures/dup-quote-long.txt
+++ b/tests/fixtures/dup-quote-long.txt
@@ -1,0 +1,14 @@
+Daily Reflection
+* Left * Right
+### "EMOTIONAL SOBRIETY"
+July XX
+**My stability came out of trying to give, not out of demanding that I receive.**
+**Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.**
+**THE LANGUAGE OF THE HEART, p. 238**
+**My stability came out of trying to give, not out of demanding that I receive.**
+**Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.**
+**THE LANGUAGE OF THE HEART, p. 238**
+
+Body paragraph continues here if present...
+
+[Daily Reflections.]

--- a/tests/fixtures/dup-quote-variant.txt
+++ b/tests/fixtures/dup-quote-variant.txt
@@ -1,6 +1,10 @@
-### "I AM AN INSTRUMENT"
-July 11
-** "We ask  simply  that throughout the day..." **
-** Big Book p. 86 **
-**“We ask simply that throughout the day…”**
-**Big Book p.86**
+Daily Reflection
+* Left * Right
+### "EMOTIONAL SOBRIETY"
+July XX
+** “My stability came out of trying to give, not out of demanding that I receive.” **
+** “Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.” **
+** THE LANGUAGE OF THE HEART, p. 238 **
+** "My stability came out of trying to give, not out of demanding that I receive." **
+** "Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety." **
+** THE LANGUAGE OF THE HEART, p. 238 **

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -64,21 +64,23 @@ export function parseJinaText(raw){
   }
   while(i<lines.length && !lines[i].trim()) i++;
   if(i<lines.length){out.date=lines[i].trim();i++;}
-  const quotes=[], seen=new Set();
-  while(i<lines.length){
-    const rawLine=lines[i];
-    const t=rawLine.trim();
+  const rawQuotes=[];
+  while(i<lines.length && rawQuotes.length<6){
+    const t=lines[i].trim();
     if(!t || !t.startsWith('**')) break;
+    rawQuotes.push(t);
+    i++;
+  }
+  const quotes=[],bodyPrepend=[],seen=new Set();
+  for(const t of rawQuotes){
     let q=t.replace(/^\*+|\*+$/g,'').trim();
     q=q.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
     q=q.replace(/\s+/g,' ');
     const canon=q.toLowerCase().replace(/[^\w.\s]/g,'');
-    if(q && !seen.has(canon)){
-      seen.add(canon);
-      quotes.push(q);
-      if(quotes.length>=2){i++;break;}
-    }
-    i++;
+    if(!q || seen.has(canon)) continue;
+    seen.add(canon);
+    if(q.length>160) bodyPrepend.push(q);
+    else if(quotes.length<2) quotes.push(q);
   }
   out.quotes=quotes;
   const foot=[/^\*\s+Left/i,/^\*\s+Right/i,/Plain text via/i,/Make a Contribution/i,/Online Bookstore/i,/Select your language/i];
@@ -90,6 +92,7 @@ export function parseJinaText(raw){
     p.push(t);
   }
   if(p.length) paras.push(p.join(' '));
+  if(bodyPrepend.length) paras.unshift(...bodyPrepend);
   out.body=paras.join('\n\n').trim();
   return out;
 }

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -37,20 +37,23 @@ function parseJinaText(raw){
   }
   while(i<lines.length && !lines[i].trim()) i++;
   if(i<lines.length){out.date=lines[i].trim();i++;}
-  const quotes=[],seen=new Set();
-  while(i<lines.length){
+  const rawQuotes=[];
+  while(i<lines.length && rawQuotes.length<6){
     const t=lines[i].trim();
     if(!t || !t.startsWith('**')) break;
+    rawQuotes.push(t);
+    i++;
+  }
+  const quotes=[],bodyPrepend=[],seen=new Set();
+  for(const t of rawQuotes){
     let q=t.replace(/^\*+|\*+$/g,'').trim();
     q=q.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
     q=q.replace(/\s+/g,' ');
     const canon=q.toLowerCase().replace(/[^\w.\s]/g,'');
-    if(q && !seen.has(canon)){
-      seen.add(canon);
-      quotes.push(q);
-      if(quotes.length>=2){i++;break;}
-    }
-    i++;
+    if(!q || seen.has(canon)) continue;
+    seen.add(canon);
+    if(q.length>160) bodyPrepend.push(q);
+    else if(quotes.length<2) quotes.push(q);
   }
   out.quotes=quotes;
   const foot=[/^\*\s+Left/i,/^\*\s+Right/i,/Plain text via/i,/Make a Contribution/i,/Online Bookstore/i,/Select your language/i];
@@ -62,6 +65,7 @@ function parseJinaText(raw){
     p.push(t);
   }
   if(p.length) paras.push(p.join(' '));
+  if(bodyPrepend.length) paras.unshift(...bodyPrepend);
   out.body=paras.join('\n\n').trim();
   return out;
 }
@@ -84,6 +88,7 @@ function render(d){
   h+=`<footer class="dr-foot">From <em>Daily Reflections</em>. Copyright \u00A9 1990 A.A. World Services, Inc. <a href="https://www.aa.org/daily-reflections" target="_blank" rel="noopener">View at AA.org</a></footer>`;
   card.innerHTML=h;
 }
+window.parseJinaText=parseJinaText;
 fetchText().then(t=>render(parseJinaText(t))).catch(()=>render(null));
 </script>
 </body>


### PR DESCRIPTION
## Summary
- improve quote dedupe logic and promote long quote lines to body
- expose `parseJinaText` globally for easier debugging
- add failing fixtures and update parsing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687887478e308327982bc4c8eb71abb8