### PR TITLE
Fix duplicate quote clusters in Daily Reflections

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -39,6 +39,8 @@ const dupQuote=fs.readFileSync(new URL('../tests/fixtures/dup-quote.txt', import
 const dupQuoteRaw=fs.readFileSync(new URL('../tests/fixtures/dup-quote-raw.txt', import.meta.url),'utf8');
 const dupQuoteVariant=fs.readFileSync(new URL('../tests/fixtures/dup-quote-variant.txt', import.meta.url),'utf8');
 const dupQuoteLong=fs.readFileSync(new URL('../tests/fixtures/dup-quote-long.txt', import.meta.url),'utf8');
+const liveDupCluster=fs.readFileSync(new URL('../tests/fixtures/live-dup-cluster.txt', import.meta.url),'utf8');
+const liveDupVariant=fs.readFileSync(new URL('../tests/fixtures/live-dup-variant.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -146,4 +148,22 @@ test('handles long quote block dedupe and promotion',()=>{
   expect(match?.length).toBe(1);
   expect(res.body.startsWith('Thus I think it can work out with emotional sobriety')).toBe(true);
   expect(res.body).not.toMatch(/Left \* Right/);
+});
+
+test('dedupes duplicated quote clusters',()=>{
+  const p=parseJinaText(liveDupCluster);
+  expect(p.quotes.length).toBeLessThanOrEqual(2);
+  expect(p.quotes[0]).toMatch(/My stability came out of trying to give/i);
+  expect(p.quotes[1]).toMatch(/THE LANGUAGE OF THE HEART/i);
+  expect(p.body).toMatch(/Thus I think it can work out with emotional sobriety/i);
+  expect((p.body.match(/emotional sobriety/gi) || []).length).toBe(2);
+});
+
+test('dedupes variant quote clusters with curly quotes',()=>{
+  const p=parseJinaText(liveDupVariant);
+  expect(p.quotes.length).toBeLessThanOrEqual(2);
+  expect(p.quotes[0]).toMatch(/My stability came out of trying to give/i);
+  expect(p.quotes[1]).toMatch(/THE LANGUAGE OF THE HEART/i);
+  expect(p.body).toMatch(/Thus I think it can work out with emotional sobriety/i);
+  expect((p.body.match(/emotional sobriety/gi) || []).length).toBe(2);
 });

--- a/tests/fixtures/live-dup-cluster.txt
+++ b/tests/fixtures/live-dup-cluster.txt
@@ -1,0 +1,14 @@
+Daily Reflection
+* Left * Right
+### "EMOTIONAL SOBRIETY"
+July XX
+**My stability came out of trying to give, not out of demanding that I receive.**
+**Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.**
+**THE LANGUAGE OF THE HEART, p. 238**
+**My stability came out of trying to give, not out of demanding that I receive.**
+**Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.**
+**THE LANGUAGE OF THE HEART, p. 238**
+
+Years of dependency on alcohol as a chemical mood-changer deprived me of the capability to interact emotionally with my fellows. I thought I had to be self-sufficient, self-reliant, and self-motivated in a world of unreliable people. Finally I lost my self-respect and was left with dependency, lacking any ability to trust myself or to believe in anything. Surrender and self-examination while sharing with newcomers helped me to ask humbly for help.
+
+[Daily Reflections.]

--- a/tests/fixtures/live-dup-variant.txt
+++ b/tests/fixtures/live-dup-variant.txt
@@ -1,0 +1,14 @@
+Daily Reflection
+* Left * Right
+### "EMOTIONAL SOBRIETY"
+July XX
+** “My stability came out of trying to give, not out of demanding that I receive.” **
+** “Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety.” **
+** THE LANGUAGE OF THE HEART, p. 238 **
+** "My stability came out of trying to give, not out of demanding that I receive." **
+** "Thus I think it can work out with emotional sobriety. If we examine every disturbance we have, great or small, we will find at the root of it some unhealthy dependency and its consequent unhealthy demand. Let us, with God's help, continually surrender these hobbling demands. Then we can be set free to live and love; we may then be able to Twelfth Step ourselves and others into emotional sobriety." **
+** THE LANGUAGE OF THE HEART, p. 238 **
+
+Years of dependency on alcohol as a chemical mood-changer deprived me of the capability to interact emotionally with my fellows. I thought I had to be self-sufficient, self-reliant, and self-motivated in a world of unreliable people. Finally I lost my self-respect and was left with dependency, lacking any ability to trust myself or to believe in anything. Surrender and self-examination while sharing with newcomers helped me to ask humbly for help.
+
+[Daily Reflections.]

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -65,23 +65,29 @@ export function parseJinaText(raw){
   while(i<lines.length && !lines[i].trim()) i++;
   if(i<lines.length){out.date=lines[i].trim();i++;}
   const rawQuotes=[];
-  while(i<lines.length && rawQuotes.length<6){
+  while(i<lines.length && rawQuotes.length<12){
     const t=lines[i].trim();
     if(!t || !t.startsWith('**')) break;
     rawQuotes.push(t);
     i++;
+    if(i<lines.length && !lines[i].trim()) break;
   }
-  const quotes=[],bodyPrepend=[],seen=new Set();
+  const quoteCandidates=[],bodyPrepend=[],qMap=new Map(),bMap=new Map();
   for(const t of rawQuotes){
     let q=t.replace(/^\*+|\*+$/g,'').trim();
     q=q.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
     q=q.replace(/\s+/g,' ');
-    const canon=q.toLowerCase().replace(/[^\w.\s]/g,'');
-    if(!q || seen.has(canon)) continue;
-    seen.add(canon);
-    if(q.length>160) bodyPrepend.push(q);
-    else if(quotes.length<2) quotes.push(q);
+    const canon=q.toLowerCase().replace(/[^a-z0-9.\s]/gi,'').trim();
+    if(!q) continue;
+    if(q.length>160){
+      if(!bMap.has(canon)){bMap.set(canon,true);bodyPrepend.push(q);}
+    }else{
+      if(!qMap.has(canon)){qMap.set(canon,true);quoteCandidates.push(q);}
+    }
   }
+  const quotes=quoteCandidates.slice(0,2);
+  console.debug('[DR] quotes:', quotes);
+  console.debug('[DR] bodyPrepend:', bodyPrepend);
   out.quotes=quotes;
   const foot=[/^\*\s+Left/i,/^\*\s+Right/i,/Plain text via/i,/Make a Contribution/i,/Online Bookstore/i,/Select your language/i];
   const paras=[]; let p=[];

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -38,23 +38,29 @@ function parseJinaText(raw){
   while(i<lines.length && !lines[i].trim()) i++;
   if(i<lines.length){out.date=lines[i].trim();i++;}
   const rawQuotes=[];
-  while(i<lines.length && rawQuotes.length<6){
+  while(i<lines.length && rawQuotes.length<12){
     const t=lines[i].trim();
     if(!t || !t.startsWith('**')) break;
     rawQuotes.push(t);
     i++;
+    if(i<lines.length && !lines[i].trim()) break;
   }
-  const quotes=[],bodyPrepend=[],seen=new Set();
+  const quoteCandidates=[],bodyPrepend=[],qMap=new Map(),bMap=new Map();
   for(const t of rawQuotes){
     let q=t.replace(/^\*+|\*+$/g,'').trim();
     q=q.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
     q=q.replace(/\s+/g,' ');
-    const canon=q.toLowerCase().replace(/[^\w.\s]/g,'');
-    if(!q || seen.has(canon)) continue;
-    seen.add(canon);
-    if(q.length>160) bodyPrepend.push(q);
-    else if(quotes.length<2) quotes.push(q);
+    const canon=q.toLowerCase().replace(/[^a-z0-9.\s]/gi,'').trim();
+    if(!q) continue;
+    if(q.length>160){
+      if(!bMap.has(canon)){bMap.set(canon,true);bodyPrepend.push(q);}
+    }else{
+      if(!qMap.has(canon)){qMap.set(canon,true);quoteCandidates.push(q);}
+    }
   }
+  const quotes=quoteCandidates.slice(0,2);
+  console.debug('[DR] quotes:', quotes);
+  console.debug('[DR] bodyPrepend:', bodyPrepend);
   out.quotes=quotes;
   const foot=[/^\*\s+Left/i,/^\*\s+Right/i,/Plain text via/i,/Make a Contribution/i,/Online Bookstore/i,/Select your language/i];
   const paras=[];let p=[];


### PR DESCRIPTION
## Summary
- improve quote parsing and deduplication logic
- move long quote lines into the body
- add fixtures for duplicate quote clusters
- test coverage for new cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788a20de808327a8a3b9f4443a7f71