### PR TITLE
Fix duplicate quote lines with SHA-1 dedupe

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -41,6 +41,8 @@ const dupQuoteVariant=fs.readFileSync(new URL('../tests/fixtures/dup-quote-varia
 const dupQuoteLong=fs.readFileSync(new URL('../tests/fixtures/dup-quote-long.txt', import.meta.url),'utf8');
 const liveDupCluster=fs.readFileSync(new URL('../tests/fixtures/live-dup-cluster.txt', import.meta.url),'utf8');
 const liveDupVariant=fs.readFileSync(new URL('../tests/fixtures/live-dup-variant.txt', import.meta.url),'utf8');
+const dupQuoteJuly19=fs.readFileSync(new URL('../tests/fixtures/dup-quote-july19.txt', import.meta.url),'utf8');
+const dupQuoteHashVariant=fs.readFileSync(new URL('../tests/fixtures/dup-quote-hash-variant.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -166,4 +168,18 @@ test('dedupes variant quote clusters with curly quotes',()=>{
   expect(p.quotes[1]).toMatch(/THE LANGUAGE OF THE HEART/i);
   expect(p.body).toMatch(/Thus I think it can work out with emotional sobriety/i);
   expect((p.body.match(/emotional sobriety/gi) || []).length).toBe(2);
+});
+
+test('dedupes July 19 duplicated quote cluster',()=>{
+  const p=parseJinaText(dupQuoteJuly19);
+  expect(p.quotes.length).toBe(2);
+  expect(p.quotes[0]).toMatch(/Many of us who had thought ourselves religious/i);
+  expect(p.quotes[1]).toMatch(/TWELVE STEPS AND TWELVE TRADITIONS/i);
+});
+
+test('dedupes quote hash variants',()=>{
+  const p=parseJinaText(dupQuoteHashVariant);
+  expect(p.quotes.length).toBe(2);
+  expect(p.quotes[0]).toMatch(/Many of us who had thought ourselves religious/i);
+  expect(p.quotes[1]).toMatch(/TWELVE STEPS AND TWELVE TRADITIONS/i);
 });

--- a/tests/fixtures/dup-quote-hash-variant.txt
+++ b/tests/fixtures/dup-quote-hash-variant.txt
@@ -1,0 +1,10 @@
+Daily Reflection
+### FALSE PRIDE
+July 19
+**“Many  of us who had thought ourselves  religious awoke to the limitations of this attitude. Refusing  to place God first, we had deprived ourselves of His help.”**
+**TWELVE   STEPS AND TWELVE TRADITIONS, p. 75**
+**"Many of us who had thought  ourselves religious awoke to the limitations of this attitude. Refusing to place God first, we had deprived ourselves of His help."**
+**TWELVE STEPS AND TWELVE  TRADITIONS, p. 75**
+
+Many false notions operate in false pride. ...
+[Daily Reflections.]

--- a/tests/fixtures/dup-quote-july19.txt
+++ b/tests/fixtures/dup-quote-july19.txt
@@ -1,0 +1,10 @@
+Daily Reflection
+### FALSE PRIDE
+July 19
+**Many of us who had thought ourselves religious awoke to the limitations of this attitude. Refusing to place God first, we had deprived ourselves of His help.**
+**TWELVE STEPS AND TWELVE TRADITIONS, p. 75**
+**Many of us who had thought ourselves religious awoke to the limitations of this attitude. Refusing to place God first, we had deprived ourselves of His help.**
+**TWELVE STEPS AND TWELVE TRADITIONS, p. 75**
+
+Many false notions operate in false pride. ...
+[Daily Reflections.]

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -52,6 +52,30 @@ export function parseDailyRss(xml){
   return res.body?res:{title,body:res.body?res.body.trim():''};
 }
 
+function sha1(str){
+  const utf8=new TextEncoder().encode(str);
+  const words=[];for(let i=0;i<utf8.length;i++)
+    words[i>>2]|=utf8[i]<<((3-(i%4))<<3);
+  words[utf8.length>>2]|=0x80<<((3-(utf8.length%4))<<3);
+  words[((utf8.length+8>>6)<<4)+15]=utf8.length<<3;
+  let h0=0x67452301,h1=0xefcdab89,h2=0x98badcfe,h3=0x10325476,h4=0xc3d2e1f0;
+  for(let i=0;i<words.length;i+=16){
+    const w=words.slice(i,i+16);
+    for(let t=16;t<80;t++) w[t]=rotl(w[t-3]^w[t-8]^w[t-14]^w[t-16],1);
+    let a=h0,b=h1,c=h2,d=h3,e=h4;
+    for(let t=0;t<80;t++){
+      const s=t>>5;
+      const f=s===0?((b&c)|(~b&d)):s===1?(b^c^d):s===2?((b&c)|(b&d)|(c&d)):(b^c^d);
+      const k=[0x5a827999,0x6ed9eba1,0x8f1bbcdc,0xca62c1d6][s];
+      const temp=(rotl(a,5)+f+e+k+w[t])>>>0;
+      e=d;d=c;c=rotl(b,30);b=a;a=temp;
+    }
+    h0=(h0+a)>>>0;h1=(h1+b)>>>0;h2=(h2+c)>>>0;h3=(h3+d)>>>0;h4=(h4+e)>>>0;
+  }
+  return [h0,h1,h2,h3,h4].map(x=>('00000000'+x.toString(16)).slice(-8)).join('');
+}
+function rotl(n,b){return(n<<b)|(n>>>32-b);} 
+
 export function parseJinaText(raw){
   raw=raw.replace(/\r/g,'');
   const lines=raw.split('\n');
@@ -73,19 +97,22 @@ export function parseJinaText(raw){
     if(i<lines.length && !lines[i].trim()) break;
   }
   const quoteCandidates=[],bodyPrepend=[],qMap=new Map(),bMap=new Map();
+  const hashList=[];
   for(const t of rawQuotes){
     let q=t.replace(/^\*+|\*+$/g,'').trim();
     q=q.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
     q=q.replace(/\s+/g,' ');
     const canon=q.toLowerCase().replace(/[^a-z0-9.\s]/gi,'').trim();
+    const h=sha1(canon);
     if(!q) continue;
     if(q.length>160){
-      if(!bMap.has(canon)){bMap.set(canon,true);bodyPrepend.push(q);}
+      if(!bMap.has(h)){bMap.set(h,true);bodyPrepend.push(q);hashList.push(h);}
     }else{
-      if(!qMap.has(canon)){qMap.set(canon,true);quoteCandidates.push(q);}
+      if(!qMap.has(h)){qMap.set(h,true);quoteCandidates.push(q);hashList.push(h);}
     }
   }
   const quotes=quoteCandidates.slice(0,2);
+  console.debug('[DR] uniqueQuoteHashes', hashList);
   console.debug('[DR] quotes:', quotes);
   console.debug('[DR] bodyPrepend:', bodyPrepend);
   out.quotes=quotes;

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -25,6 +25,28 @@ async function fetchText(){
   if(!r.ok) throw new Error('fetch');
   return r.text();
 }
+function sha1(str){
+  const utf8=new TextEncoder().encode(str);
+  const words=[];for(let i=0;i<utf8.length;i++) words[i>>2]|=utf8[i]<<((3-(i%4))<<3);
+  words[utf8.length>>2]|=0x80<<((3-(utf8.length%4))<<3);
+  words[((utf8.length+8>>6)<<4)+15]=utf8.length<<3;
+  let h0=0x67452301,h1=0xefcdab89,h2=0x98badcfe,h3=0x10325476,h4=0xc3d2e1f0;
+  for(let i=0;i<words.length;i+=16){
+    const w=words.slice(i,i+16);
+    for(let t=16;t<80;t++) w[t]=rotl(w[t-3]^w[t-8]^w[t-14]^w[t-16],1);
+    let a=h0,b=h1,c=h2,d=h3,e=h4;
+    for(let t=0;t<80;t++){
+      const s=t>>5;
+      const f=s===0?((b&c)|(~b&d)):s===1?(b^c^d):s===2?((b&c)|(b&d)|(c&d)):(b^c^d);
+      const k=[0x5a827999,0x6ed9eba1,0x8f1bbcdc,0xca62c1d6][s];
+      const temp=(rotl(a,5)+f+e+k+w[t])>>>0;
+      e=d;d=c;c=rotl(b,30);b=a;a=temp;
+    }
+    h0=(h0+a)>>>0;h1=(h1+b)>>>0;h2=(h2+c)>>>0;h3=(h3+d)>>>0;h4=(h4+e)>>>0;
+  }
+  return [h0,h1,h2,h3,h4].map(x=>('00000000'+x.toString(16)).slice(-8)).join('');
+}
+function rotl(n,b){return(n<<b)|(n>>>32-b);}
 function parseJinaText(raw){
   raw=raw.replace(/\r/g,'');
   const lines=raw.split('\n');
@@ -46,19 +68,22 @@ function parseJinaText(raw){
     if(i<lines.length && !lines[i].trim()) break;
   }
   const quoteCandidates=[],bodyPrepend=[],qMap=new Map(),bMap=new Map();
+  const hashList=[];
   for(const t of rawQuotes){
     let q=t.replace(/^\*+|\*+$/g,'').trim();
     q=q.replace(/^['"“”‘’]+|['"“”‘’]+$/g,'').trim();
     q=q.replace(/\s+/g,' ');
     const canon=q.toLowerCase().replace(/[^a-z0-9.\s]/gi,'').trim();
+    const h=sha1(canon);
     if(!q) continue;
     if(q.length>160){
-      if(!bMap.has(canon)){bMap.set(canon,true);bodyPrepend.push(q);}
+      if(!bMap.has(h)){bMap.set(h,true);bodyPrepend.push(q);hashList.push(h);}
     }else{
-      if(!qMap.has(canon)){qMap.set(canon,true);quoteCandidates.push(q);}
+      if(!qMap.has(h)){qMap.set(h,true);quoteCandidates.push(q);hashList.push(h);}
     }
   }
   const quotes=quoteCandidates.slice(0,2);
+  console.debug('[DR] uniqueQuoteHashes', hashList);
   console.debug('[DR] quotes:', quotes);
   console.debug('[DR] bodyPrepend:', bodyPrepend);
   out.quotes=quotes;


### PR DESCRIPTION
## Summary
- hash normalized quote lines via SHA-1 to remove duplicates
- log unique hashes when parsing Daily Reflection text
- test duplicate cluster from July 19 sample
- test hash-based dedupe across punctuation variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b2b9c15808327942305324b9ac613