### PR TITLE
Add render-time dedupe for Daily Reflections widget

### DIFF
--- a/__tests__/daily-reflections-render.test.js
+++ b/__tests__/daily-reflections-render.test.js
@@ -1,0 +1,11 @@
+import {parseJinaText, renderBlockquote} from '../widgets/daily-reflections-lib.js';
+import fs from 'fs';
+
+const dupText = fs.readFileSync(new URL('../tests/fixtures/false-pride-dup.txt', import.meta.url), 'utf8');
+
+test('renderBlockquote dedupes identical quote pairs', () => {
+  const p = parseJinaText(dupText);
+  const html = renderBlockquote(p.quotes);
+  const match = html.match(/<p\b/gi) || [];
+  expect(match.length).toBe(2);
+});

--- a/tests/fixtures/false-pride-dup.txt
+++ b/tests/fixtures/false-pride-dup.txt
@@ -1,0 +1,8 @@
+Daily Reflection
+### FALSE PRIDE
+July 19
+**Many of us who had thought ourselves religious awoke to the limitations of this attitude. Refusing to place God first, we had deprived ourselves of His help.**
+**TWELVE STEPS AND TWELVE TRADITIONS, p. 75**
+**Many of us who had thought ourselves religious awoke to the limitations of this attitude. Refusing to place God first, we had deprived ourselves of His help.**
+**TWELVE STEPS AND TWELVE TRADITIONS, p. 75**
+[Daily Reflections.]

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -129,3 +129,18 @@ export function parseJinaText(raw){
   out.body=paras.join('\n\n').trim();
   return out;
 }
+
+export function renderBlockquote(quotes=[]){
+  if(!quotes||!quotes.length) return '';
+  const seen=new Set();
+  const out=[];
+  for(const q of quotes){
+    const canon=q.toLowerCase().trim().replace(/\s+/g,' ').replace(/[^a-z0-9.\s]/gi,'');
+    if(!seen.has(canon)){seen.add(canon);out.push(q);}
+  }
+  const uniq=out.slice(0,2);
+  console.debug('[DR] postRender quotes', uniq);
+  if(uniq.length===1) return `<blockquote><p class="dr-quote">${uniq[0]}</p></blockquote>`;
+  if(uniq.length>=2) return `<blockquote><p class="dr-quote">${uniq[0]}</p><p class="dr-quote-src">${uniq[1]}</p></blockquote>`;
+  return '';
+}

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -100,17 +100,27 @@ function parseJinaText(raw){
   out.body=paras.join('\n\n').trim();
   return out;
 }
+function renderBlockquote(quotes){
+  if(!quotes||!quotes.length) return '';
+  const seen=new Set();
+  const out=[];
+  for(const q of quotes){
+    const canon=q.toLowerCase().trim().replace(/\s+/g,' ').replace(/[^a-z0-9.\s]/gi,'');
+    if(!seen.has(canon)){seen.add(canon);out.push(q);}
+  }
+  const uniq=out.slice(0,2);
+  console.debug('[DR] postRender quotes', uniq);
+  if(uniq.length===1) return `<blockquote><p class="dr-quote">${uniq[0]}</p></blockquote>`;
+  if(uniq.length>=2) return `<blockquote><p class="dr-quote">${uniq[0]}</p><p class="dr-quote-src">${uniq[1]}</p></blockquote>`;
+  return '';
+}
 function render(d){
   const card=document.getElementById('card');
   if(!d) return card.innerHTML='<p>Unable to load today\'s Daily Reflection.</p>';
   let h=`<h2>${d.title}</h2>`;
   if(d.date) h+=`<div class="date">${d.date}</div>`;
   if(d.quotes && d.quotes.length){
-    if(d.quotes.length===1){
-      h+=`<blockquote><p class="dr-quote">${d.quotes[0]}</p></blockquote>`;
-    }else if(d.quotes.length>=2){
-      h+=`<blockquote><p class="dr-quote">${d.quotes[0]}</p><p class="dr-quote-src">${d.quotes[1]}</p></blockquote>`;
-    }
+    h+=renderBlockquote(d.quotes);
   }
   if(d.body){
     const ps=d.body.split(/\n\n+/).map(p=>`<p>${p}</p>`).join('');


### PR DESCRIPTION
## Summary
- add a final dedupe pass when rendering the Daily Reflections widget
- expose `renderBlockquote` from the lib for testing/consumers
- integrate the new function in the widget HTML
- add fixture and tests for duplicate quote rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b309b28c08327bd68d348a789e469