### PR TITLE
Finalize render-time dedupe notes

### DIFF
--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -130,6 +130,8 @@ export function parseJinaText(raw){
   return out;
 }
 
+// Final safeguard: dedupe quotes right before rendering so any
+// downstream logic can never surface duplicates.
 export function renderBlockquote(quotes=[]){
   if(!quotes||!quotes.length) return '';
   const seen=new Set();

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -100,6 +100,8 @@ function parseJinaText(raw){
   out.body=paras.join('\n\n').trim();
   return out;
 }
+// Final safeguard: dedupe quotes again before inserting HTML so
+// duplicate blocks can never appear.
 function renderBlockquote(quotes){
   if(!quotes||!quotes.length) return '';
   const seen=new Set();


### PR DESCRIPTION
## Summary
- add inline notes explaining the final render-time dedupe logic
- keep the existing tests ensuring duplicates are stripped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b326d2ae08327b90faf1e0e5a7823