### PR TITLE
Fix DR render time quote deduping

### DIFF
--- a/__tests__/daily-reflections.test.js
+++ b/__tests__/daily-reflections.test.js
@@ -43,6 +43,7 @@ const liveDupCluster=fs.readFileSync(new URL('../tests/fixtures/live-dup-cluster
 const liveDupVariant=fs.readFileSync(new URL('../tests/fixtures/live-dup-variant.txt', import.meta.url),'utf8');
 const dupQuoteJuly19=fs.readFileSync(new URL('../tests/fixtures/dup-quote-july19.txt', import.meta.url),'utf8');
 const dupQuoteHashVariant=fs.readFileSync(new URL('../tests/fixtures/dup-quote-hash-variant.txt', import.meta.url),'utf8');
+const falsePrideDup=fs.readFileSync(new URL('../tests/fixtures/false-pride-dup.txt', import.meta.url),'utf8');
 
 test('filters leftover navigation text',()=>{
   const {title,body}=parsePlainText(sample3);
@@ -182,4 +183,11 @@ test('dedupes quote hash variants',()=>{
   expect(p.quotes.length).toBe(2);
   expect(p.quotes[0]).toMatch(/Many of us who had thought ourselves religious/i);
   expect(p.quotes[1]).toMatch(/TWELVE STEPS AND TWELVE TRADITIONS/i);
+});
+
+test('dedupes false pride duplicate lines',()=>{
+  const p=parseJinaText(falsePrideDup);
+  expect(p.quotes.length).toBe(2);
+  expect(p.quotes[0]).toMatch(/Many of us who had thought/i);
+  expect(p.quotes[1]).toMatch(/TWELVE STEPS/i);
 });

--- a/tests/fixtures/false-pride-dup.txt
+++ b/tests/fixtures/false-pride-dup.txt
@@ -5,4 +5,7 @@ July 19
 **TWELVE STEPS AND TWELVE TRADITIONS, p. 75**
 **Many of us who had thought ourselves religious awoke to the limitations of this attitude. Refusing to place God first, we had deprived ourselves of His help.**
 **TWELVE STEPS AND TWELVE TRADITIONS, p. 75**
+
+Paragraph text…
+
 [Daily Reflections.]

--- a/widgets/daily-reflections-lib.js
+++ b/widgets/daily-reflections-lib.js
@@ -133,14 +133,15 @@ export function parseJinaText(raw){
 // Final safeguard: dedupe quotes right before rendering so any
 // downstream logic can never surface duplicates.
 export function renderBlockquote(quotes=[]){
-  if(!quotes||!quotes.length) return '';
+  if(!quotes || !quotes.length) return '';
   const seen=new Set();
-  const out=[];
+  const deduped=[];
   for(const q of quotes){
     const canon=q.toLowerCase().trim().replace(/\s+/g,' ').replace(/[^a-z0-9.\s]/gi,'');
-    if(!seen.has(canon)){seen.add(canon);out.push(q);}
+    if(!seen.has(canon)){seen.add(canon);deduped.push(q);}
   }
-  const uniq=out.slice(0,2);
+  if(deduped.length>2) throw new Error('DR dedupe failed');
+  const uniq=deduped.slice(0,2);
   console.debug('[DR] postRender quotes', uniq);
   if(uniq.length===1) return `<blockquote><p class="dr-quote">${uniq[0]}</p></blockquote>`;
   if(uniq.length>=2) return `<blockquote><p class="dr-quote">${uniq[0]}</p><p class="dr-quote-src">${uniq[1]}</p></blockquote>`;

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -105,12 +105,13 @@ function parseJinaText(raw){
 function renderBlockquote(quotes){
   if(!quotes||!quotes.length) return '';
   const seen=new Set();
-  const out=[];
+  const deduped=[];
   for(const q of quotes){
     const canon=q.toLowerCase().trim().replace(/\s+/g,' ').replace(/[^a-z0-9.\s]/gi,'');
-    if(!seen.has(canon)){seen.add(canon);out.push(q);}
+    if(!seen.has(canon)){seen.add(canon);deduped.push(q);}
   }
-  const uniq=out.slice(0,2);
+  if(deduped.length>2) throw new Error('DR dedupe failed');
+  const uniq=deduped.slice(0,2);
   console.debug('[DR] postRender quotes', uniq);
   if(uniq.length===1) return `<blockquote><p class="dr-quote">${uniq[0]}</p></blockquote>`;
   if(uniq.length>=2) return `<blockquote><p class="dr-quote">${uniq[0]}</p><p class="dr-quote-src">${uniq[1]}</p></blockquote>`;


### PR DESCRIPTION
## Summary
- dedupe quotes at render time and assert 2 max
- keep Daily Reflections widget in sync
- update false pride fixture
- test parseJinaText with duplicate sample

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b3587a3408327b52a6ea509a9a8be