### PR TITLE
Add global dedupe for Daily Reflections

### DIFF
--- a/__tests__/daily-reflections-render.test.js
+++ b/__tests__/daily-reflections-render.test.js
@@ -1,11 +1,11 @@
-import {parseJinaText, renderBlockquote} from '../widgets/daily-reflections-lib.js';
+import {parseJinaText, buildBlockquote} from '../widgets/daily-reflections-lib.js';
 import fs from 'fs';
 
 const dupText = fs.readFileSync(new URL('../tests/fixtures/false-pride-dup.txt', import.meta.url), 'utf8');
 
-test('renderBlockquote dedupes identical quote pairs', () => {
+test('buildBlockquote dedupes identical quote pairs', () => {
   const p = parseJinaText(dupText);
-  const html = renderBlockquote(p.quotes);
+  const html = buildBlockquote(p.quotes);
   const match = html.match(/<p\b/gi) || [];
   expect(match.length).toBe(2);
 });

--- a/__tests__/render-dedupe.test.js
+++ b/__tests__/render-dedupe.test.js
@@ -1,4 +1,4 @@
-import { dedupeRenderQuotes } from '../widgets/daily-reflections-lib.js';
+import { buildBlockquote } from '../widgets/daily-reflections-lib.js';
 
 test('render-time dedupe', () => {
   const arr = [
@@ -7,7 +7,7 @@ test('render-time dedupe', () => {
     'Quote line A',
     'Source line B'
   ];
-  const out = dedupeRenderQuotes(arr);
+  const out = buildBlockquote.dedupe(arr).slice(0,2);
   expect(out.length).toBe(2);
   expect(out[0]).toMatch(/Quote line A/i);
   expect(out[1]).toMatch(/Source line B/i);

--- a/tests/render-dedupe-final.test.js
+++ b/tests/render-dedupe-final.test.js
@@ -1,0 +1,15 @@
+import { buildBlockquote } from '../widgets/daily-reflections-lib.js';
+
+test('global dedupe removes non-consecutive duplicates', () => {
+  const raw = [
+    'Quote A',
+    'Source B',
+    'Quote A',           // dup
+    'Source B',          // dup
+    'Quote A',           // dup again
+  ];
+  const uniq = buildBlockquote.dedupe(raw);
+  expect(uniq.length).toBe(2);
+  expect(uniq[0]).toMatch(/Quote A/i);
+  expect(uniq[1]).toMatch(/Source B/i);
+});

--- a/widgets/daily-reflections.html
+++ b/widgets/daily-reflections.html
@@ -100,26 +100,28 @@ function parseJinaText(raw){
   out.body=paras.join('\n\n').trim();
   return out;
 }
-// Final safeguard: dedupe quotes again before inserting HTML so
-// duplicate blocks can never appear.
-function dedupeRenderQuotes(arr=[]){
-  const canonical=l=>l.toLowerCase().trim().replace(/[“”"']/g,'').replace(/\s+/g,' ');
-  const unique=[];
-  let prev='';
-  for(const line of arr){
-    const canon=canonical(line);
-    if(canon && canon!==prev) unique.push(line);
-    prev=canon;
+// Final safeguard: dedupe quote lines globally so duplicates can never appear.
+function dedupe(rawQuotes=[]){
+  const canonical=str=>str.toLowerCase().trim().replace(/[“”"']/g,'').replace(/\s+/g,' ');
+  const seen=new Set();
+  const uniq=[];
+  for(const line of rawQuotes){
+    const key=canonical(line);
+    if(!seen.has(key)){
+      seen.add(key);
+      uniq.push(line);
+    }
   }
-  if(unique.length!==arr.length) console.debug('[DR] duplicates removed');
-  return unique.slice(0,2);
+  if(rawQuotes.length!==uniq.length) console.debug('[DR] removed dupes',rawQuotes.length-uniq.length);
+  return uniq;
 }
-function renderBlockquote(quotes){
-  const uniq=dedupeRenderQuotes(quotes);
-  if(!uniq.length) return '';
-  console.debug('[DR] postRender quotes', uniq);
-  if(uniq.length===1) return `<blockquote><p class="dr-quote">${uniq[0]}</p></blockquote>`;
-  if(uniq.length>=2) return `<blockquote><p class="dr-quote">${uniq[0]}</p><p class="dr-quote-src">${uniq[1]}</p></blockquote>`;
+function buildBlockquote(rawQuotes=[]){
+  const uniq=dedupe(rawQuotes);
+  const limited=uniq.slice(0,2);
+  if(!limited.length) return '';
+  console.debug('[DR] postRender quotes', limited);
+  if(limited.length===1) return `<blockquote><p class="dr-quote">${limited[0]}</p></blockquote>`;
+  if(limited.length>=2) return `<blockquote><p class="dr-quote">${limited[0]}</p><p class="dr-quote-src">${limited[1]}</p></blockquote>`;
   return '';
 }
 function render(d){
@@ -128,7 +130,7 @@ function render(d){
   let h=`<h2>${d.title}</h2>`;
   if(d.date) h+=`<div class="date">${d.date}</div>`;
   if(d.quotes && d.quotes.length){
-    h+=renderBlockquote(d.quotes);
+    h+=buildBlockquote(d.quotes);
   }
   if(d.body){
     const ps=d.body.split(/\n\n+/).map(p=>`<p>${p}</p>`).join('');
@@ -138,6 +140,8 @@ function render(d){
   card.innerHTML=h;
 }
 window.parseJinaText=parseJinaText;
+buildBlockquote.dedupe=dedupe;
+window.buildBlockquote=buildBlockquote;
 fetchText().then(t=>render(parseJinaText(t))).catch(()=>render(null));
 </script>
 </body>


### PR DESCRIPTION
## Summary
- enforce set-based dedupe when rendering Daily Reflection quotes
- expose `buildBlockquote` with `dedupe` helper for tests
- update widget JS to use `buildBlockquote`
- update node library and tests
- add regression test for global dedupe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb66de6948327ba3a20141bb13307